### PR TITLE
Fix error that occurs when method is undefined

### DIFF
--- a/src/bugsnag.ios.ts
+++ b/src/bugsnag.ios.ts
@@ -68,7 +68,9 @@ function BSGParseJavaScriptStacktrace(stacktrace: string) {
     const bundleURL = NSBundle.mainBundle.bundleURL;
     while (match != null) {
         const frame = NSMutableDictionary.new();
-        frame.setObjectForKey(match[1], 'method');
+        if (!!match[1]) {
+            frame.setObjectForKey(match[1], 'method');
+        }
         if (!!match[2]) {
             frame.setObjectForKey(parseInt(match[4], 10), 'columnNumber');
             frame.setObjectForKey(parseInt(match[3], 10), 'lineNumber');


### PR DESCRIPTION
Hey there, I'm using your library in an NS-Vue project and was running into errors trying to use `notify` since the method associated with a line in the stacktrace can sometimes be `undefined`. This PR updates the iOS stacktrace parsing logic to skip over undefined methods.