### PR TITLE
Fix broken code example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ new Promise(function(resolve, reject) {
   /* potentially failing code */
 })
 .then(function () { /* if the promise is resolved */ })
-.catch(bugsnag.notify); // if the promise is rejected
+.catch(function (error) {
+  bugsnag.notify(error)
+}); // if the promise is rejected
 ```
 
 # Sending diagnostic data

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ new Promise(function(resolve, reject) {
 })
 .then(function () { /* if the promise is resolved */ })
 .catch(function (error) {
-  bugsnag.notify(error)
-}); // if the promise is rejected
+  bugsnag.notify(error) /* if the promise is rejected */
+});
 ```
 
 # Sending diagnostic data


### PR DESCRIPTION
This PR fixes some example code from the README that results in an error. `bugsnag.notify` needs to be called from within a callback function in a promise's `catch` block, otherwise the `notify` method fails because `this` is undefined.

Relevant error message:
`TypeError: undefined is not an object (evaluating 'this.config')`